### PR TITLE
Use OpenAPI instead of Springfox Swagger for API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,9 +93,9 @@
             <version>3.0.5</version>
         </dependency>
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-boot-starter</artifactId>
-            <version>3.0.0</version>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>6.5.0</version>
+            <version>8.2.1</version>
             <type>maven-plugin</type>
         </dependency>
     </dependencies>
@@ -188,7 +188,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.5.0</version>
+                <version>8.2.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/madadipouya/eris/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/madadipouya/eris/configuration/SwaggerConfiguration.java
@@ -1,55 +1,46 @@
 package com.madadipouya.eris.configuration;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-
-import java.util.Collections;
-
-import static springfox.documentation.builders.PathSelectors.regex;
 
 /*
-* This file is part of Eris Weather API.
-*
-* Eris Weather API is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License version 3
-* as published by the Free Software Foundation.
-*
-* Eris Weather API is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.  <http://www.gnu.org/licenses/>
-*
-* Author(s):
-*
-* © 2017-2022 Kasra Madadipouya <kasra@madadipouya.com>
-*/
+ * This file is part of Eris Weather API.
+ *
+ * Eris Weather API is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * Eris Weather API is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.  <http://www.gnu.org/licenses/>
+ *
+ * Author(s):
+ *
+ * © 2017-2023 Kasra Madadipouya <kasra@madadipouya.com>
+ */
 
 @Configuration
 public class SwaggerConfiguration {
 
     @Bean
-    public Docket productApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("com.madadipouya.eris.rest"))
-                .paths(regex("/v1/weather/.*"))
-                .build()
-                .apiInfo(metaData());
+    public OpenAPI apiInfo() {
+        return new OpenAPI().info(new Info().title("Eris API documentation")
+                .description("Documentation for Eris weather API")
+                .version("v1")
+                .contact(getContactDetails())
+                .license(getLicenseDetails()));
     }
 
-    ApiInfo metaData() {
-        return new ApiInfo(
-                "Eris API documentation",
-                "Documentation for Eris weather API",
-                "v1",
-                "Free of charge",
-                new Contact("Kasra Madadipouya", "https://eris.madadipouya.com", "kasra@madadipouya.com"),
-                "GNU General Public License v3.0",
-                "https://github.com/kasramp/Eris/blob/develop/LICENSE", Collections.emptyList());
+    private Contact getContactDetails() {
+        return new Contact().name("Kasra Madadipouya").email("kasra@madadipouya.com").url("https://eris.madadipouya.com");
+    }
+
+    private License getLicenseDetails() {
+        return new License().name("GNU General Public License v3.0").url("https://github.com/kasramp/Eris/blob/develop/LICENSE");
     }
 }

--- a/src/main/java/com/madadipouya/eris/rest/CurrentWeatherAPIController.java
+++ b/src/main/java/com/madadipouya/eris/rest/CurrentWeatherAPIController.java
@@ -2,9 +2,10 @@ package com.madadipouya.eris.rest;
 
 import com.madadipouya.eris.service.weather.Weather;
 import com.madadipouya.eris.service.weather.model.CurrentWeatherCondition;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,21 +19,21 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.math.NumberUtils.isCreatable;
 
 /*
-* This file is part of Eris Weather API.
-*
-* Eris Weather API is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License version 3
-* as published by the Free Software Foundation.
-*
-* Eris Weather API is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.  <http://www.gnu.org/licenses/>
-*
-* Author(s):
-*
-* © 2017-2022 Kasra Madadipouya <kasra@madadipouya.com>
-*/
+ * This file is part of Eris Weather API.
+ *
+ * Eris Weather API is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * Eris Weather API is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.  <http://www.gnu.org/licenses/>
+ *
+ * Author(s):
+ *
+ * © 2017-2023 Kasra Madadipouya <kasra@madadipouya.com>
+ */
 
 @RestController
 public class CurrentWeatherAPIController {
@@ -48,12 +49,14 @@ public class CurrentWeatherAPIController {
     }
 
     /*
-    *
-    * "/current" is kept for backward compatibility, will be deprecated soon
-    *
-    * */
-    @ApiOperation(value = "Get current weather condition based on latitude and longitude", response = CurrentWeatherCondition.class, tags = "Get weather by latitude, longitude")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully retrieve weather condition"), @ApiResponse(code = 400, message = "Failed to get weather condition")})
+     *
+     * "/current" is kept for backward compatibility, will be deprecated soon
+     *
+     * */
+    @Operation(summary = "Get current weather condition based on latitude and longitude",
+            parameters = {@Parameter(name = "lat", description = "Latitude of a location", required = true), @Parameter(name = "lon", description = "Longitude of a location", required = true),
+                    @Parameter(name = "fahrenheit", description = "Return weather temperatures in Fahrenheit instead of Celsius (default)")}, tags = "Get weather by latitude, longitude")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Successfully retrieve weather condition"), @ApiResponse(responseCode = "400", description = "Failed to get weather condition")})
     @GetMapping(value = {"v1/weather/current", "/current"}, produces = "application/json")
     public Callable<ResponseEntity<CurrentWeatherCondition>> getCurrent(@RequestParam(value = "lat") String latitude, @RequestParam(value = "lon") String longitude,
                                                                         @RequestParam(value = "fahrenheit", required = false, defaultValue = "false") boolean fahrenheit,
@@ -67,8 +70,8 @@ public class CurrentWeatherAPIController {
         }
     }
 
-    @ApiOperation(value = "Get current weather condition based on requester IP address", response = CurrentWeatherCondition.class, tags = "Get weather by requester IP address")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Successfully retrieve weather condition"), @ApiResponse(code = 400, message = "Failed to get weather condition")})
+    @Operation(summary = "Get current weather condition based on requester IP address", tags = "Get weather by requester IP address")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Successfully retrieve weather condition"), @ApiResponse(responseCode = "400", description = "Failed to get weather condition")})
     @GetMapping(value = {"v1/weather/currentbyip"}, produces = "application/json")
     public Callable<ResponseEntity<CurrentWeatherCondition>> getCurrentByIp(@RequestParam(value = "fahrenheit",
             required = false, defaultValue = "false") boolean fahrenheit, HttpServletRequest request) {

--- a/src/main/java/com/madadipouya/eris/rest/Redirect.java
+++ b/src/main/java/com/madadipouya/eris/rest/Redirect.java
@@ -7,21 +7,21 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 
 /*
-* This file is part of Eris Weather API.
-*
-* Eris Weather API is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License version 3
-* as published by the Free Software Foundation.
-*
-* Eris Weather API is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.  <http://www.gnu.org/licenses/>
-*
-* Author(s):
-*
-* © 2017-2022 Kasra Madadipouya <kasra@madadipouya.com>
-*/
+ * This file is part of Eris Weather API.
+ *
+ * Eris Weather API is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * Eris Weather API is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.  <http://www.gnu.org/licenses/>
+ *
+ * Author(s):
+ *
+ * © 2017-2023 Kasra Madadipouya <kasra@madadipouya.com>
+ */
 
 @RestController
 public class Redirect {
@@ -33,8 +33,8 @@ public class Redirect {
         return new ModelAndView("redirect:" + request.getScheme() + DOC_URL);
     }
 
-    @GetMapping(value = "/apidocs")
+    @GetMapping(value = {"/apidocs", "/api-docs"})
     public ModelAndView redirectToApiPage() {
-        return new ModelAndView("redirect:/swagger-ui/");
+        return new ModelAndView("redirect:/swagger-ui/index.html");
     }
 }

--- a/src/test/java/com/madadipouya/eris/configuration/SwaggerConfigurationTest.java
+++ b/src/test/java/com/madadipouya/eris/configuration/SwaggerConfigurationTest.java
@@ -1,17 +1,34 @@
 package com.madadipouya.eris.configuration;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.ApiSelectorBuilder;
-import springfox.documentation.spring.web.plugins.Docket;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+/*
+ * This file is part of Eris Weather API.
+ *
+ * Eris Weather API is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * Eris Weather API is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.  <http://www.gnu.org/licenses/>
+ *
+ * Author(s):
+ *
+ * © 2017-2023 Kasra Madadipouya <kasra@madadipouya.com>
+ */
 
 
 @ExtendWith(MockitoExtension.class)
@@ -21,29 +38,22 @@ class SwaggerConfigurationTest {
     private SwaggerConfiguration swaggerConfiguration;
 
     @Test
-    void testGetSwaggerApiInfo() {
-        ApiInfo apiInfo = swaggerConfiguration.metaData();
-        Contact contact = apiInfo.getContact();
+    void testOpenApiContactDetails() {
+        OpenAPI openAPI = swaggerConfiguration.apiInfo();
+        Info apiInfo = openAPI.getInfo();
+        Contact contactDetails = openAPI.getInfo().getContact();
+        License licenseDetails = openAPI.getInfo().getLicense();
+
         assertNotNull(apiInfo);
-        assertNotNull(contact);
+        assertNotNull(contactDetails);
+        assertNotNull(licenseDetails);
         assertEquals("Eris API documentation", apiInfo.getTitle());
         assertEquals("Documentation for Eris weather API", apiInfo.getDescription());
         assertEquals("v1", apiInfo.getVersion());
-        assertEquals("Free of charge", apiInfo.getTermsOfServiceUrl());
-        assertEquals("GNU General Public License v3.0", apiInfo.getLicense());
-        assertEquals("https://github.com/kasramp/Eris/blob/develop/LICENSE", apiInfo.getLicenseUrl());
-        assertEquals(0, apiInfo.getVendorExtensions().size());
-        assertEquals("Kasra Madadipouya", contact.getName());
-        assertEquals("https://eris.madadipouya.com", contact.getUrl());
-        assertEquals("kasra@madadipouya.com", contact.getEmail());
-    }
-
-    @Test
-    void testProductApi() {
-        Docket docket = swaggerConfiguration.productApi();
-        ApiSelectorBuilder builder = docket.select();
-        assertNotNull(docket);
-        assertEquals(DocumentationType.SWAGGER_2, docket.getDocumentationType());
-        assertNotNull(builder);
+        assertEquals("Kasra Madadipouya", contactDetails.getName());
+        assertEquals("kasra@madadipouya.com", contactDetails.getEmail());
+        assertEquals("https://eris.madadipouya.com", contactDetails.getUrl());
+        assertEquals("GNU General Public License v3.0", licenseDetails.getName());
+        assertEquals("https://github.com/kasramp/Eris/blob/develop/LICENSE", licenseDetails.getUrl());
     }
 }

--- a/src/test/java/com/madadipouya/eris/rest/RedirectTest.java
+++ b/src/test/java/com/madadipouya/eris/rest/RedirectTest.java
@@ -14,21 +14,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /*
-* This file is part of Eris Weather API.
-*
-* Eris Weather API is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License version 3
-* as published by the Free Software Foundation.
-*
-* Eris Weather API is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.  <http://www.gnu.org/licenses/>
-*
-* Author(s):
-*
-* © 2017-2022 Kasra Madadipouya <kasra@madadipouya.com>
-*/
+ * This file is part of Eris Weather API.
+ *
+ * Eris Weather API is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * Eris Weather API is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.  <http://www.gnu.org/licenses/>
+ *
+ * Author(s):
+ *
+ * © 2017-2023 Kasra Madadipouya <kasra@madadipouya.com>
+ */
 
 @ExtendWith(MockitoExtension.class)
 class RedirectTest {
@@ -48,6 +48,6 @@ class RedirectTest {
     @Test
     void testRedirectToApiDocs() {
         ModelAndView page = redirectController.redirectToApiPage();
-        assertEquals("redirect:/swagger-ui/", page.getViewName());
+        assertEquals("redirect:/swagger-ui/index.html", page.getViewName());
     }
 }


### PR DESCRIPTION
As Springfox Swagger project is unmaintained, see #17, the objective of this PR is to get rid of it and instead use OpenAPI library, so that Spring Boot can be upgraded to version 3.