### PR TITLE
Disable CI (manual) analysis of Sonar

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -23,18 +23,25 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '25'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-${{ github.ref_name }}-sonar
-          restore-keys: ${{ runner.os }}-${{ github.ref_name }}-sonar
-      - name: Build and analyze
+#      Using automatic Sonar Analysis that also runs on PRs automatically without any configuration needed.
+#      It's good enough for now for what Eris project does.
+#      - name: Cache SonarCloud packages
+#        uses: actions/cache@v4
+#        with:
+#          path: ~/.sonar/cache
+#          key: ${{ runner.os }}-${{ github.ref_name }}-sonar
+#          restore-keys: ${{ runner.os }}-${{ github.ref_name }}-sonar
+#      - name: Build and analyze
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+#        run: mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=kasramp -Dsonar.projectKey=kasramp_Eris
+      - name: Build and test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=kasramp -Dsonar.projectKey=kasramp_Eris
+        run: mvn clean install
       - uses: actions/checkout@v4
       - name: Set last commit
         shell: bash


### PR DESCRIPTION
Letting Sonar to run automatically (by default, configurable through the dashboard) to do all the analysis. It makes life much easier and simpler as it also runs on PRs without a fuss or extra configuration. For Eris need, it's something that's great and further complication is really not needed at this stage.